### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/schema-converter/avro-schema-converter/src/main/java/org/apache/rocketmq/schema/avro/AvroData.java
+++ b/schema-converter/avro-schema-converter/src/main/java/org/apache/rocketmq/schema/avro/AvroData.java
@@ -1098,7 +1098,7 @@ public class AvroData {
                             .enumeration(schema.getParameters().get(AVRO_TYPE_ENUM))
                             .doc(enumDoc)
                             .defaultSymbol(enumDefault)
-                            .symbols(symbols.toArray(new String[symbols.size()]));
+                            .symbols(symbols.toArray(new String[0]));
                 } else {
                     // common string
                     baseSchema = org.apache.avro.SchemaBuilder.builder().stringType();


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:595300799 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (1)
